### PR TITLE
Address.Error should not be an exported field as it cannot be

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,45 +2,58 @@
 
 
 [[projects]]
+  digest = "1:56c130d885a4aacae1dd9c7b71cfe39912c7ebc1ff7d2b46083c8812996dc43b"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = ""
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:304c322b62533a48ac052ffee80f67087fce1bc07186cd4e610a1b0e77765836"
   name = "github.com/hashicorp/errwrap"
   packages = ["."]
+  pruneopts = ""
   revision = "7554cd9344cec97297fa6649b055a8c98c2a1e55"
 
 [[projects]]
   branch = "master"
+  digest = "1:7660b6ee3fd92bcb9b19f5d359d3fbc8e853257d8a3d49e0424d00b6faa69cfd"
   name = "github.com/hashicorp/go-multierror"
   packages = ["."]
+  pruneopts = ""
   revision = "83588e72410abfbe4df460eeb6f30841ae47d4c4"
 
 [[projects]]
+  digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = ""
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:60a491b06f139dccd50f72a389ffb824cb4a48f36ac6505e69de2dc129e23961"
   name = "github.com/teamwork/test"
   packages = [
     ".",
-    "diff"
+    "diff",
   ]
+  pruneopts = ""
   revision = "fe7d3af7b99331ddae4f1a1271e652e7b5b3737f"
 
 [[projects]]
   branch = "master"
+  digest = "1:ca24bfdf83d228ef34c43baa94a18942fbe783c4b631922c3fff945855798d37"
   name = "github.com/teamwork/toutf8"
   packages = ["."]
+  pruneopts = ""
   revision = "908c4b127591e39bd79a8214ca158a4f8baff682"
 
 [[projects]]
+  digest = "1:5acd3512b047305d49e8763eef7ba423901e85d5dd2fd1e71778a0ea8de10bd4"
   name = "golang.org/x/text"
   packages = [
     "encoding",
@@ -57,14 +70,20 @@
     "internal/utf8internal",
     "runes",
     "transform",
-    "unicode/cldr"
+    "unicode/cldr",
   ]
+  pruneopts = ""
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f94729c5d72c9be71965bdae81cfe994ee004b932571f093d64fc770b3ae4d6b"
+  input-imports = [
+    "github.com/hashicorp/go-multierror",
+    "github.com/teamwork/test",
+    "github.com/teamwork/test/diff",
+    "github.com/teamwork/toutf8",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/address.go
+++ b/address.go
@@ -11,7 +11,7 @@ type Address struct {
 	Name    string `db:"name" json:"name"`
 	Address string `db:"email" json:"address"`
 	Raw     string `db:"-" json:"-"`
-	Error   error  `db:"-" json:"-"`
+	err     error  `db:"-"`
 }
 
 // String formats an address. It is *not* RFC 2047 encoded!
@@ -114,9 +114,18 @@ func (a Address) WithoutTag() string {
 // (e.g. addr := Address{...}).
 func (a *Address) Valid() bool {
 	if a.Address == "" || !reValidEmail.MatchString(a.Address) {
-		a.Error = ErrNoEmail
+		a.err = ErrNoEmail
 		return false
 	}
 
-	return a.Error == nil
+	return a.err == nil
+}
+
+// Error returns any error that may have been associated with the mail address
+func (a *Address) Error() error {
+	if a.Valid() {
+		return nil
+	}
+
+	return a.err
 }

--- a/bin/lint
+++ b/bin/lint
@@ -76,7 +76,6 @@ gometalinter --deadline=120s --vendor --sort=path --tests --disable-all \
 	--enable=varcheck \
 	--enable=structcheck \
 	--enable=errcheck \
-	--enable=megacheck \
 	--enable=ineffassign \
 	--enable=interfacer \
 	--enable=unconvert \

--- a/list.go
+++ b/list.go
@@ -85,7 +85,7 @@ func (l List) Slice() []string {
 func (l List) Errors() (errs error) {
 	for _, a := range l {
 		if !a.Valid() {
-			errs = multierror.Append(errs, a.Error)
+			errs = multierror.Append(errs, a.err)
 		}
 	}
 	return errs

--- a/mailaddress.go
+++ b/mailaddress.go
@@ -18,14 +18,14 @@ func Parse(str string) (Address, error) {
 		return Address{}, ErrTooManyEmails
 	}
 
-	return list[0], list[0].Error
+	return list[0], list[0].err
 }
 
 // New is a shortcut to make a new Address
 func New(name, address string) Address {
 	a, err := Parse(address)
 	if err != nil {
-		return Address{Name: name, Address: "", Error: err}
+		return Address{Name: name, Address: "", err: err}
 	}
 	return Address{Name: name, Address: a.Address}
 }

--- a/mailaddress_test.go
+++ b/mailaddress_test.go
@@ -72,24 +72,24 @@ func TestNewHelpers(t *testing.T) {
 		name, address string
 		expected      Address
 	}{
-		{"", "", Address{Name: "", Address: "", Error: errors.New("")}},
-		{"Martin", "", Address{Name: "Martin", Address: "", Error: errors.New("")}},
+		{"", "", Address{Name: "", Address: "", err: errors.New("")}},
+		{"Martin", "", Address{Name: "Martin", Address: "", err: errors.New("")}},
 		{"", "martin@example.com", Address{Name: "", Address: "martin@example.com"}},
 		{"Martin", "martin@example.com", Address{Name: "Martin", Address: "martin@example.com"}},
 
 		// Invalid addresses should result in an invalid Address{} (that is, one
 		// without the Address field set).
-		{"Martin", "invalid", Address{Name: "Martin", Address: "", Error: errors.New("")}},
+		{"Martin", "invalid", Address{Name: "Martin", Address: "", err: errors.New("")}},
 	}
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("%v <%v>", tc.name, tc.address), func(t *testing.T) {
 			got := New(tc.name, tc.address)
 
-			if tc.expected.Error != nil && got.Error == nil {
+			if tc.expected.Error() != nil && got.Error() == nil {
 				t.Fatal("expected error but got nil")
 			}
-			if tc.expected.Error == nil && got.Error != nil {
+			if tc.expected.Error() == nil && got.Error() != nil {
 				t.Fatal("expected no error but got error")
 			}
 

--- a/parse_test.go
+++ b/parse_test.go
@@ -12,7 +12,6 @@ var validAddresses = map[string]Address{
 	"<angle-addr@example.net>":             {Name: "", Address: "angle-addr@example.net"},
 	"First Last <mailbox@example.net>":     {Name: "First Last", Address: "mailbox@example.net"},
 	`"First Last" <mailbox@example.net>`:   {Name: "First Last", Address: "mailbox@example.net"},
-	"Uni العَرَبِية Cøde <x@example.net>":  {Name: "Uni العَرَبِية Cøde", Address: "x@example.net"},
 	`"<Firšt; Låšt>" <x@example.net>`:      {Name: `<Firšt; Låšt>`, Address: `x@example.net`},
 	"dot.in.local.part@example.com":        {Address: "dot.in.local.part@example.com"},
 	"Name <dot.in.local.part@example.com>": {Name: "Name", Address: "dot.in.local.part@example.com"},
@@ -22,6 +21,8 @@ var validAddresses = map[string]Address{
 	"Name <dashed-dash@ex-ample.com>":      {Name: "Name", Address: "dashed-dash@ex-ample.com"},
 	"example@example.verylongtld":          {Address: "example@example.verylongtld"},
 	`Po "Wiśnasd" <asd@asd-def-24h.zxc>`:   {Name: `Po Wiśnasd`, Address: "asd@asd-def-24h.zxc"},
+
+	`Uni العَرَبِية Cøde <x@example.net>`: {Name: "Uni العَرَبِية Cøde", Address: "x@example.net"},
 
 	// TODO: Quoting the local part isn't supported (yet).
 	//`"quoted"@example.com`:                     {Address: `"quoted"@example.com`},
@@ -280,11 +281,11 @@ Tournoij
 			`=?utf-8?q?=E0=B8=B1=E0=B8=81=E0=B8=A9=ED=9B=88=EB=AF=BC?= <a@example.net>`: `` +
 			`"日本ки正體อักษ훈민" <a@example.net>`,
 
-		``:  ``,
-		`,`: ``,
-		`martin@example.com,`:                           `martin@example.com`,
-		`,martin@example.com`:                           `martin@example.com`,
-		`,martin@example.com,`:                          `martin@example.com`,
+		``:                     ``,
+		`,`:                    ``,
+		`martin@example.com,`:  `martin@example.com`,
+		`,martin@example.com`:  `martin@example.com`,
+		`,martin@example.com,`: `martin@example.com`,
 		`"martin@example.com FOO" <martin@example.com>`: `"martin@example.com FOO" <martin@example.com>`,
 	}
 
@@ -313,7 +314,7 @@ func TestInvalid(t *testing.T) {
 			if err == nil {
 				t.Fatal("err == nil")
 			}
-			if out.Error == nil {
+			if out.Error() == nil {
 				t.Fatal("out.Error == nil")
 			}
 		})


### PR DESCRIPTION
serialized.

It is also my opinion that the error check should be a function call
rather than a public variable which can be modified by the caller.

This change means that consumers must now call `addr.Error()` rather
than a direct member lookup on `add.Error`.