### PR TITLE
support semicolon as address list separator

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -110,7 +110,7 @@ func parse(str string) (list List, haveError bool) {
 			inAddress = false
 
 		// Next <address>
-		case !inQuote && chr == ",":
+		case !inQuote && (chr == "," || chr == ";"): // ';' introduced by outlook
 			haveError = end(&addr) || haveError
 			if addr.Name != "" || addr.Address != "" || addr.err != nil {
 				list = append(list, addr)

--- a/parse_test.go
+++ b/parse_test.go
@@ -145,8 +145,6 @@ var invalidAddresses = []string{
 	`smellycats612@aol..com`,
 	`concretesawing@comcast.net13113602@dwsg`,
 	`MM522@aol.com315=269-5244`,
-	`;foo@example.com`,
-	`foo@example.com;`,
 	`"much.more unusual"@example.com`,
 
 	// quoted strings must be dot separated or the only element making up the


### PR DESCRIPTION
https://digitalcrew.teamwork.com/#/tasks/16841980
https://tools.ietf.org/html/rfc5322#section-3.4.1

Meanwhile at [M$](https://stackoverflow.com/questions/12120190/what-is-the-best-separator-to-separate-multiple-emails/24570917#24570917) 

![giphy](https://user-images.githubusercontent.com/32456194/89203791-c3725d80-d57a-11ea-863f-fd35d4767564.gif)


