### PR TITLE
Fix parse list address raw to not be wrapped by whitespaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.13.x
+  - 1.16.x
 go_import_path: github.com/teamwork/mailaddress
 notifications:
   email: false

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/teamwork/mailaddress
 
-go 1.13
+go 1.16
 
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect

--- a/mailaddress_test.go
+++ b/mailaddress_test.go
@@ -21,6 +21,10 @@ func TestParseList(t *testing.T) {
 		{``, List{}, false},
 		{`asd`, List{Address{Raw: "asd"}}, true},
 		{"Martin <martin@example.com>", List{Address{Name: "Martin", Address: "martin@example.com"}}, false},
+		{"\"Martin, What\" <martin@example.com>, another@foo.com", List{
+			Address{Raw: "\"Martin, What\" <martin@example.com>", Name: "Martin, What", Address: "martin@example.com"},
+			Address{Raw: "another@foo.com", Address: "another@foo.com"},
+		}, false},
 	}
 
 	for _, tc := range cases {

--- a/parse.go
+++ b/parse.go
@@ -147,6 +147,7 @@ func parse(str string) (list List, haveError bool) {
 
 func end(a *Address) (goterror bool) {
 	a.Name = strings.TrimSpace(a.Name)
+	a.Raw = strings.TrimSpace(a.Raw)
 
 	// Remove any RFC 2047 encoding. Any encoded word is a single <atom>
 	// (i.e. characters such as comma, <, ", etc. don't get interpreted in


### PR DESCRIPTION
When parsing list of address, the raw value of not the first address is appended by a whitespace because of the white space following a comma

# Example

`"Martin, What" <martin@example.com>, another@foo.com`
Prev raw values
```
"\"Martin, What\" <martin@example.com>"
" another@foo.com:
```
Proposed raw values
```
"\"Martin, What\" <martin@example.com>"
"another@foo.com:
```
note the initial white space on the second address