### PR TITLE
Remove uniq from UnmarshalJSON

### DIFF
--- a/list.go
+++ b/list.go
@@ -32,7 +32,7 @@ func (l *List) UnmarshalJSON(data []byte) error {
 	var alias Alias
 	err := json.Unmarshal(data, &alias)
 	if err == nil {
-		*l = List(alias).uniq()
+		*l = List(alias)
 		return nil
 	}
 


### PR DESCRIPTION
`uniq` should not be called anywhere but it breaks everything if removed